### PR TITLE
Add .wasm requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,7 @@ name = "simple-synth"
 version = "0.1.0"
 dependencies = [
  "cpal",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+crate-type = ["cdylib"]
+
 [dependencies]
 cpal = "0.15.0"
+wasm-bindgen = "0.2.84"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use std::f32::consts::PI;
 use std::time::Duration;
+use std::sync::Arc;
+use wasm_bindgen::prelude::*;
 
 // Definimos una estructura para los parámetros de un oscilador
 struct OscillatorParams {
@@ -91,3 +93,26 @@ fn create_oscillator(frequency: f32, amplitude: f32, waveform: Waveform, speed: 
     };
     Oscillator::new(params)
 }
+
+// Indicamos que nuestra función será exportada al lado de JavaScript
+#[wasm_bindgen]
+pub fn next_sample(sample_rate: f32, frequency: f32, amplitude: f32, waveform: u32, speed: f32, phase: f32) -> f32 {
+    // Convertimos el valor del enumerador de Waveform a un valor real
+    let waveform = match waveform {
+        0 => Waveform::Sine,
+        1 => Waveform::Square,
+        2 => Waveform::Sawtooth,
+        _ => Waveform::Sine,
+    };
+
+    // Creamos el oscilador y calculamos el siguiente valor de muestra
+    let mut oscillator = Oscillator::new(OscillatorParams {
+        frequency,
+        amplitude,
+        waveform,
+        speed,
+        phase,
+    });
+    oscillator.next_sample(sample_rate)
+}
+


### PR DESCRIPTION
To build a WebAssembly file from the Rust project first this needs to be converted in a library (lib.rs for example).
This pull request adds the needed refactor and the public function to be invoked when WebAssembly binary is compiled.